### PR TITLE
Improve IMAP and SSL/TLS Support, Add Email Headers, Add Runtime Paramters

### DIFF
--- a/check_email_loop
+++ b/check_email_loop
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-my $scriptversion = "1.4.4";
+my $scriptversion = "1.4.5";
 my $scriptdate = "2018-07-11";
 #
 # check_email_loop Nagios Plugin
@@ -83,6 +83,9 @@ my $scriptdate = "2018-07-11";
 # - Correct IMAP SSL/TLS port default from 585 to 993
 # - Correct missing require for IO::Socket::SSL if using explicit IMAP SSL
 # - Make "INBOX" the default $imapfolder
+#
+# 2018-07-11 v1.4.5     BowTyTroll, TheTroll@BowTyTroll.com
+# - Add missing require directive for Mail::IMAPClient, when '-useimap' given
 #
 #
 # This software is licensed under the terms and conditions of the GPLv2 license
@@ -208,6 +211,7 @@ usage() if ($showversion || $status == 0 || ! ($pophost && $popuser && $poppassw
 
 my @required_module = ();
 push @required_module, 'Email::Date::Format';
+push @required_module, 'Mail::IMAPClient' if $useimap;
 push @required_module, 'Net::SMTP::SSL' if $usesmtpssl;
 push @required_module, 'IO::Socket::SSL' if $usessl;
 push @required_module, ('MIME::Base64','Authen::SASL') if $usesmtpssl && $smtpuser;

--- a/check_email_loop
+++ b/check_email_loop
@@ -9,7 +9,7 @@ my $scriptdate = "2012-05-22";
 # an given smtp-server to a given email-adress. When the script
 # is run again, it checks for this Email (with its unique id) on
 # a given pop3 account and send another mail.
-# 
+#
 #
 # Example: check_email_loop.pl -poph=mypop -popu=user -pa=password
 # 	   -smtph=mailer -from=returnadress@yoursite.com
@@ -18,20 +18,20 @@ my $scriptdate = "2012-05-22";
 # This example will send each time this check is executed a new
 # mail to remaileradress@friend.com using the SMTP-Host mailer.
 # Then it looks for any back-forwarded mails in the POP3 host
-# mypop. In this Configuration CRITICAL state will be reached if  
-# more than 2 Mails are pending (meaning that they did not came 
+# mypop. In this Configuration CRITICAL state will be reached if
+# more than 2 Mails are pending (meaning that they did not came
 # back till now) or if a mails got lost (meaning a mail, that was
 # send later came back prior to another mail).
-# 
+#
 # 2000     v1.0         Benjamin Schmid, blueshift@gmx.net
 #   - Initial release into the wild.
 #
-# 2006                  Michael Markstaller, mm@elabnet.de 
+# 2006                  Michael Markstaller, mm@elabnet.de
 #  - fixed some unquoted strings
 #  - fixed/added pendwarn/lostwarn
-#  - added deleting of orphaned check-emails 
+#  - added deleting of orphaned check-emails
 #    changed to use "top" instead of get to minimize traffic
-#    (required changing match-string from "Subject: Email-ping [" 
+#    (required changing match-string from "Subject: Email-ping ["
 #     to "Email-Ping ["
 #  - Allow multiple mail-servers (separate stats files via target server hash).
 #
@@ -47,30 +47,30 @@ my $scriptdate = "2012-05-22";
 #  - Added forgetafter param
 #  Remaining Bugs:
 #  - Try to delete matched id already marked for deletion
-#  - "interval" param yet has no effect 
+#  - "interval" param yet has no effect
 #
 # 2008-05    v1.3       Johannes Derek
 #  - Added Support for SMTP Authentication (code taken from check_email_delivery)
 #  - SMTP TLS Support working, SMTP SSL Support not tested
 #
-# 2008-09    v1.3.1     James W., September 2008, 
+# 2008-09    v1.3.1     James W., September 2008,
 #  - sanity check for required Authen:SASL module
 #
-# 2010-10-09 v1.4.0     Arjen Heidinga <arjen.heidinga@anachron.com> 
+# 2010-10-09 v1.4.0     Arjen Heidinga <arjen.heidinga@anachron.com>
 #  (NOTE: This branch forked of v.1.3.1 and did not include the minor
 #         stabilization fixes of the 'oldstable' version 1.3.2 to 1.3.3
 #  - Added IMAP4 support. (Still a bit dirty code)
 #  - Some code cleanups, fix a lot of warnings.
 #
 # 2010-10-09 v1.4.1     Frieder B.
-# -  Contribution of IMAP4 STARTTLS support using option -usestarttls. 
+# -  Contribution of IMAP4 STARTTLS support using option -usestarttls.
 #
 # 2011-08-30 v1.4.2     Frieder B.
 # - Deferred on-demand loading of POP3 / IMAP libs
 # - Custom E-Mail subject which allows to reuse the same inbox for multiple loops
 # - New -sendnomail and -sendmailonly option
 #
-# 2012-05-22 v1.4.3     Benjamin Schmid, blueshift@gmx.net 
+# 2012-05-22 v1.4.3     Benjamin Schmid, blueshift@gmx.net
 # - Started Git repository & realizing the big version mess
 # - Minor cleanups to the hacks starting with IMAP fork of v.1.3.1
 # - Ommit perl warnings
@@ -105,7 +105,7 @@ my ($keeporphaned, $useimap, $showversion);
 my ($smtphost, $smtpuser, $smtppasswd, $smtpport);
 my ($trashall,$usessl,$forgetafter);
 my ($usestarttls);
-my ($subjectident) = ("E-Mail Ping"); 
+my ($subjectident) = ("E-Mail Ping");
 my ($sendmailonly,$sendnomail);
 my ($usesendmail) = ("");
 my ($usesmtpssl,$usesmtptls);
@@ -214,7 +214,7 @@ if (open STATF, "$statfile") {
   close STATF;
 }
 
-# Try to open statfile for writing 
+# Try to open statfile for writing
 if (!open STATF, ">$statfile") {
   nsexit("Failed to open mail-ID database $statfile for writing",'CRITICAL');
 } else {
@@ -275,7 +275,7 @@ foreach my $id (@messageids) {
 }
 
 # creating new serial id
-my $timenow = time();  
+my $timenow = time();
 my $serial = "ID#" . $timenow . "#$$";
 
 # Ok - check if it's time to release another mail
@@ -286,8 +286,8 @@ if (!defined($sendnomail)) {
 if ( $debug == 1  ) {
     $other_smtp_opts{'Debug'} = 1;
 }
-my $maildata = "To: $receiver\n". 
-  "Subject: $subjectident [$serial]\n". 
+my $maildata = "To: $receiver\n".
+  "Subject: $subjectident [$serial]\n".
   "This is an automatically sent E-Mail.\n".
   "It is not intended for a human reader.\n\n".
   "Serial No: $serial\n";
@@ -348,7 +348,7 @@ else {
  $smtp->quit;
 # ) || nsexit("Error delivering message",'CRITICAL');
 } else {
-  open (SENDMAIL,"|$usesendmail -t -f $sender 2>&1") || 
+  open (SENDMAIL,"|$usesendmail -t -f $sender 2>&1") ||
                  nsexit("SENDMAIL CRITICAL - Using sendmail failed $receiver",'CRITICAL');
   print SENDMAIL $maildata;
   close SENDMAIL;
@@ -356,7 +356,7 @@ else {
 
  if (defined($sendmailonly)) {
    print "$serial\n";
- }else{ 
+ }else{
    print STATF "$serial\n";     # remember send mail of this session
    close STATF;
  }
@@ -366,7 +366,7 @@ else {
 my @tmp = grep /^ID/, @messageids;
 my $pendingm = scalar @tmp;
 @tmp = grep /^LI/, @messageids;
-my $lostm = scalar @tmp; 
+my $lostm = scalar @tmp;
 
 # Evaluate the Warnin/Crit-Levels
 if (defined $pendwarn && $pendingm > $pendwarn) { $state = 'WARNING'; }
@@ -374,7 +374,7 @@ if (defined $lostwarn && $lostm > $lostwarn) { $state = 'WARNING'; }
 if (defined $pendcrit && $pendingm > $pendcrit) { $state = 'CRITICAL'; }
 if (defined $lostcrit && $lostm > $lostcrit) { $state = 'CRITICAL'; }
 
-if ((defined $pendwarn || defined $pendcrit || defined $lostwarn 
+if ((defined $pendwarn || defined $pendcrit || defined $lostwarn
      || defined $lostcrit) && ($state eq 'UNKNOWN')) {$state='OK';}
 
 printd ("STATUS:\n");
@@ -491,7 +491,7 @@ sub messagematchsid {
   my ($mailref,$id) = (@_);
   my (@tmp);
   my $match = 0;
- 
+
   # ID
   $id =~ s/^LI/ID/;    # evtl. remove lost mail mark
   @tmp = grep /$subjectident \[/, @$mailref;
@@ -506,12 +506,12 @@ sub messagematchsid {
 
   # Sender:
 #  @tmp = grep /^From:\s+/, @$mailref;
-#  if (@tmp && $sender ne "") 
+#  if (@tmp && $sender ne "")
 #    { $match = $match && ($tmp[0]=~/$sender/); }
 
   # Receiver:
 #  @tmp = grep /^To: /, @$mailref;
-#  if (@tmp && $receiver ne "") 
+#  if (@tmp && $receiver ne "")
 #    { $match = $match && ($tmp[0]=~/$receiver/); }
 
   return $match;
@@ -567,32 +567,32 @@ sub doPop {
 	while ($msgcount > 0) {
 	  my $msgtext = "";
 	  my @msglines2 = ();
-	  foreach ($pop->Head($msgcount)) { 
-		#$msgtext= $msgtext . $_ . "\n"; 
+	  foreach ($pop->Head($msgcount)) {
+		#$msgtext= $msgtext . $_ . "\n";
 		push(@msglines2, $_);
 	  }
 	  #@msglines = $msgtext;
 	  for (my $i=0; $i < scalar @messageids; $i++) {
-	    if (messagematchsid(\@msglines2,$messageids[$i])) { 
+	    if (messagematchsid(\@msglines2,$messageids[$i])) {
 	      $matchcount++;
 	      printd ("Messages are matching\n");
 	      # newest received mail than the others, ok remeber id.
-	      if (!defined $newestid) { 
+	      if (!defined $newestid) {
 		$newestid = $messageids[$i];
 	      } else {
 		    $messageids[$i] =~ /\#(\d+)\#/;
 		$mid = $1;
 		    $newestid =~ /\#(\d+)\#/;
 		$nid = $1;
-		if ($mid > $nid) { 
-		  $newestid = $messageids[$i]; 
+		if ($mid > $nid) {
+		  $newestid = $messageids[$i];
 		}
 	      }
 	      printd ("Deleted retrieved mail $msgcount with messageid ".$messageids[$i]."\n");
 	      $pop->Delete($msgcount);  # remove E-Mail from POP3 server
 	      splice @messageids, $i, 1;# remove id from List
 		  last;                     # stop looking in list
-		} 
+		}
 	  }
 
 		# Messages Deleted before are marked for deletion here again
@@ -626,9 +626,9 @@ sub doImap {
 	my $imap_port;
 	$imap_port = $popport if $popport;
 	eval {
-	
+
 		if( $usessl ) {
-			$imap_port = 585 unless $popport;		
+			$imap_port = 585 unless $popport;
 			my $socket = IO::Socket::SSL->new("$pophost:$imap_port");
 			die IO::Socket::SSL::errstr() unless $socket;
 			$socket->autoflush(1);
@@ -640,14 +640,14 @@ sub doImap {
 			$imap->login() or die "$@";
 		} elsif( $usestarttls ) {
 #			# XXX  THIS PART IS NOT DONE YET ... NEED TO OPEN A REGULAR IMAP CONNECTION, THEN ISSUE THE "STARTTLS" COMMAND MANUALLY, SWITCHING THE SOCKET TO IO::SOCKET::SSL, AND THEN GIVING IT BACK TO MAIL::IMAPCLIENT ...
-#			$imap_port = $default_imap_port unless $imap_port;		
-#			$imap = Mail::IMAPClient->new(Debug => 0 );		
+#			$imap_port = $default_imap_port unless $imap_port;
+#			$imap = Mail::IMAPClient->new(Debug => 0 );
 #			$imap->Server("$imap_server:$imap_port");
 #			$imap->User($username);
 #			$imap->Password($password);
-#			$imap->connect() or die "$@";		
-			$imap_port = 143 unless $popport;		
-			$imap = Mail::IMAPClient->new(Debug => 0 );		
+#			$imap->connect() or die "$@";
+			$imap_port = 143 unless $popport;
+			$imap = Mail::IMAPClient->new(Debug => 0 );
 			$imap->Server($pophost);
 			$imap->Port($imap_port);
 			$imap->connect() or die "Unable to connect to imap server";
@@ -655,8 +655,8 @@ sub doImap {
 			$imap->tag_and_run("AUTHENTICATE PLAIN " . encode_base64("\0" . $popuser . "\0" . $poppasswd))
   				or die "Unable to login to imap server with user " . $popuser;
 		} else {
-			$imap_port = 143 unless $popport;		
-			$imap = Mail::IMAPClient->new(Debug => 0 );		
+			$imap_port = 143 unless $popport;
+			$imap = Mail::IMAPClient->new(Debug => 0 );
 			$imap->Server($pophost);
 			$imap->Port($imap_port);
 			$imap->User($popuser);
@@ -664,18 +664,18 @@ sub doImap {
 			$imap->connect() or die "$@";
 		}
 
-	};	
-	
+	};
+
 	if( $@ ) {
 		chomp $@;
 		print "IMAP RECEIVE CRITICAL - Could not connect to $pophost port $imap_port: $@\n";
-		exit $ERRORS{CRITICAL};	
+		exit $ERRORS{CRITICAL};
 	}
 	unless( $imap ) {
 		print "IMAP RECEIVE CRITICAL - Could not connect to $pophost port $imap_port: $@\n";
 		exit $ERRORS{CRITICAL};
 	}
-	
+
 	unless( $imap->select($imapfolder) ) {
 		print "IMAP RECEIVE CRITICAL - Could not select $imapfolder: $@ $!\n";
 		printd ("Well, here is a folderlist: \n" . $imap->folders() . "\n");
@@ -685,29 +685,29 @@ sub doImap {
 		$imap->logout();
 		exit $ERRORS{CRITICAL};
 	}
-	
+
 	my @messagelist = ();
 	@messagelist = $imap->search("SUBJECT \"$subjectident [\"");
 	$statinfo=@messagelist . " messages on IMAP";
-	
+
 	my ($mid, $nid);
 	foreach (@messagelist) {
 		my @msglines2 = ($imap->get_header($_, "Subject") . "\n");
 		my $mailDeleted = 0;
 		for (my $i=0; $i < scalar @messageids; $i++) {
-			if (messagematchsid(\@msglines2,$messageids[$i])) { 
+			if (messagematchsid(\@msglines2,$messageids[$i])) {
 				$matchcount++;
 				printd ("Messages are matching\n");
 				# newest received mail than the others, ok remeber id.
-				if (!defined $newestid) { 
+				if (!defined $newestid) {
 					$newestid = $messageids[$i];
 				} else {
 					$messageids[$i] =~ /\#(\d+)\#/;
 					$mid = $1;
 					$newestid =~ /\#(\d+)\#/;
 					$nid = $1;
-					if ($mid > $nid) { 
-						$newestid = $messageids[$i]; 
+					if ($mid > $nid) {
+						$newestid = $messageids[$i];
 					}
 				}
 				printd ("Deleted retrieved mail $_ with messageid ".$messageids[$i]."\n");
@@ -724,7 +724,6 @@ sub doImap {
 			$mailDeleted = 1;
 		}
 	}
-	
+
 	$imap->close();
 }
-

--- a/check_email_loop
+++ b/check_email_loop
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 #
-my $scriptversion = "1.4.3";
-my $scriptdate = "2012-05-22";
+my $scriptversion = "1.4.4";
+my $scriptdate = "2018-07-11";
 #
 # check_email_loop Nagios Plugin
 #
@@ -75,6 +75,15 @@ my $scriptdate = "2012-05-22";
 # - Minor cleanups to the hacks starting with IMAP fork of v.1.3.1
 # - Ommit perl warnings
 #
+# 2018-07-11 v1.4.4     BowTyTroll, TheTroll@BowTyTroll.com
+# - Fix SMTP auth when "-usesmtptls"/Deprecated Net::SMTP::TLS for Net::SMTP
+# - Add "-smtpehlo" option, with default value hostfqdn(), for SMTP HELO/EHLO
+# - Add RFC 2822 compliant From, Date and Message-ID headers to emails
+# - Add default imap port variables
+# - Correct IMAP SSL/TLS port default from 585 to 993
+# - Correct missing require for IO::Socket::SSL if using explicit IMAP SSL
+# - Make "INBOX" the default $imapfolder
+#
 #
 # This software is licensed under the terms and conditions of the GPLv2 license
 #   https://www.gnu.org/licenses/gpl-2.0.html
@@ -86,7 +95,9 @@ my $scriptdate = "2012-05-22";
 use MIME::Base64;
 use strict;
 use Getopt::Long;
-use Digest::MD5;
+use Digest::MD5 qw(md5 md5_hex md5_base64);
+use Net::Domain qw(hostfqdn);
+use Email::Date::Format qw(email_date);
 &Getopt::Long::config('auto_abbrev');
 
 # ----------------------------------------
@@ -100,12 +111,14 @@ my %ERRORS = ('OK' , '0',
 my ($state) = ("UNKNOWN");
 my ($sender,$receiver,$pophost,$popuser,$poppasswd) = ("","","","","","");
 my ($popauth) = "BEST";
-my ($popport, $imapfolder);
+my ($popport);
+my ($imapfolder) = ("INBOX");
 my ($keeporphaned, $useimap, $showversion);
 my ($smtphost, $smtpuser, $smtppasswd, $smtpport);
 my ($trashall,$usessl,$forgetafter);
 my ($usestarttls);
 my ($subjectident) = ("E-Mail Ping");
+my ($smtpehlo) = (hostfqdn());
 my ($sendmailonly,$sendnomail);
 my ($usesendmail) = ("");
 my ($usesmtpssl,$usesmtptls);
@@ -122,6 +135,9 @@ my ($statinfo) = ("");
 my $default_smtp_port = "25";
 my $default_smtp_ssl_port = "465";
 my $default_smtp_tls_port = "587";
+
+my $default_imap_port = "143";
+my $default_imap_ssl_port = "993";
 
 # initialize some vars
 $smtphost = "";
@@ -164,6 +180,7 @@ my $status = GetOptions(
 			"smtpuser=s",\$smtpuser,
 			"smtppasswd=s",\$smtppasswd,
 			"smtpport=i",\$smtpport,
+			"smtpehlo=s",\$smtpehlo,
 			"statfile=s",\$statfile,
 			"lostwarn=i",\$lostwarn,
 			"lostcrit=i",\$lostcrit,
@@ -190,9 +207,10 @@ usage() if ($showversion || $status == 0 || ! ($pophost && $popuser && $poppassw
 	 &! ($sendmailonly && $smtphost && $receiver && $sender ));
 
 my @required_module = ();
+push @required_module, 'Email::Date::Format';
 push @required_module, 'Net::SMTP::SSL' if $usesmtpssl;
+push @required_module, 'IO::Socket::SSL' if $usessl;
 push @required_module, ('MIME::Base64','Authen::SASL') if $usesmtpssl && $smtpuser;
-push @required_module, 'Net::SMTP::TLS' if $usesmtptls;
 push @required_module, 'Authen::SASL' if $smtpuser && !$usesmtpssl && !$usesmtptls;
 exit $ERRORS{"UNKNOWN"} unless load_modules(@required_module);
 
@@ -286,7 +304,11 @@ if (!defined($sendnomail)) {
 if ( $debug == 1  ) {
     $other_smtp_opts{'Debug'} = 1;
 }
-my $maildata = "To: $receiver\n".
+
+my $maildata = "From: <$sender>\n".
+  "To: $receiver\n".
+  "Date: " .  email_date() . "\n".
+  "Message-Id: <" . md5_hex($serial) . "\@$smtpehlo>\n".
   "Subject: $subjectident [$serial]\n".
   "This is an automatically sent E-Mail.\n".
   "It is not intended for a human reader.\n\n".
@@ -298,18 +320,21 @@ my $smtp;
 eval {
        if( $usesmtptls ) {
                $smtpport = $default_smtp_tls_port unless $smtpport;
-               $smtp = Net::SMTP::TLS->new($smtphost, Timeout=>$smtptimeout, Port=>$smtpport, User=>$smtpuser, Password=>$smtppasswd);
+               $smtp = Net::SMTP->new($smtphost, Timeout=>$smtptimeout, Port=>$smtpport, starttls=>1, Hello=>$smtpehlo, %other_smtp_opts);
+               if( $smtp && $smtpuser )  {
+                       $smtp->auth($smtpuser, $smtppasswd);
+               }
        }
        elsif( $usesmtpssl ) {
                $smtpport = $default_smtp_ssl_port unless $smtpport;
-               $smtp = Net::SMTP::SSL->new($smtphost, Port => $smtpport, Timeout=>$smtptimeout, %other_smtp_opts);
+               $smtp = Net::SMTP::SSL->new($smtphost, Port => $smtpport, Timeout=>$smtptimeout, Hello=>$smtpehlo, %other_smtp_opts);
                if( $smtp && $smtpuser )  {
                        $smtp->auth($smtpuser, $smtppasswd);
                }
        }
        else {
                $smtpport = $default_smtp_port unless $smtpport;
-               $smtp = Net::SMTP->new($smtphost, Port=>$smtpport, Timeout=>$smtptimeout,%other_smtp_opts);
+               $smtp = Net::SMTP->new($smtphost, Port=>$smtpport, Timeout=>$smtptimeout, Hello=>$smtpehlo, %other_smtp_opts);
                if( $smtp && $smtpuser ) {
                        $smtp->auth($smtpuser, $smtppasswd);
                }
@@ -425,6 +450,7 @@ sub usage {
   print "   -smtpuser=text     Name of the SMTP user\n";
   print "   -smtppasswd=text   Password of the SMTP user\n";
   print "   -smtpport=num      Port to of the SMTP service\n";
+  print "   -smtpehlo=text     FQDN to be reported to SMTP server during HELO/EHLO\n";
   print "   -smtptimeout=num   Timeout in seconds for the SMTP-server\n";
   print "   -usesmtpssl        Set this to login with ssl enabled on smtp server\n";
   print "   -usesmtptls        Set this to login with tls enabled on smtp server\n";
@@ -628,7 +654,7 @@ sub doImap {
 	eval {
 
 		if( $usessl ) {
-			$imap_port = 585 unless $popport;
+			$imap_port = $default_imap_ssl_port unless $popport;
 			my $socket = IO::Socket::SSL->new("$pophost:$imap_port");
 			die IO::Socket::SSL::errstr() unless $socket;
 			$socket->autoflush(1);
@@ -646,7 +672,7 @@ sub doImap {
 #			$imap->User($username);
 #			$imap->Password($password);
 #			$imap->connect() or die "$@";
-			$imap_port = 143 unless $popport;
+			$imap_port = $default_imap_port unless $popport;
 			$imap = Mail::IMAPClient->new(Debug => 0 );
 			$imap->Server($pophost);
 			$imap->Port($imap_port);
@@ -655,7 +681,7 @@ sub doImap {
 			$imap->tag_and_run("AUTHENTICATE PLAIN " . encode_base64("\0" . $popuser . "\0" . $poppasswd))
   				or die "Unable to login to imap server with user " . $popuser;
 		} else {
-			$imap_port = 143 unless $popport;
+			$imap_port = $default_imap_port unless $popport;
 			$imap = Mail::IMAPClient->new(Debug => 0 );
 			$imap->Server($pophost);
 			$imap->Port($imap_port);

--- a/check_email_loop
+++ b/check_email_loop
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 #
-my $scriptversion = "1.4.5";
-my $scriptdate = "2018-07-11";
+my $scriptversion = "1.4.6";
+my $scriptdate = "2018-07-14";
 #
 # check_email_loop Nagios Plugin
 #
@@ -87,6 +87,10 @@ my $scriptdate = "2018-07-11";
 # 2018-07-11 v1.4.5     BowTyTroll, TheTroll@BowTyTroll.com
 # - Add missing require directive for Mail::IMAPClient, when '-useimap' given
 #
+# 2018-07-14 v1.4.6     BowTyTroll, TheTroll@BowTyTroll.com
+# - Add statfile directory parameter ('statfiledir')
+# - Make default statfile directory the script directory (NOT working directory)
+#
 #
 # This software is licensed under the terms and conditions of the GPLv2 license
 #   https://www.gnu.org/licenses/gpl-2.0.html
@@ -101,9 +105,16 @@ use Getopt::Long;
 use Digest::MD5 qw(md5 md5_hex md5_base64);
 use Net::Domain qw(hostfqdn);
 use Email::Date::Format qw(email_date);
+use File::Basename;
+use File::Spec::Functions qw(rel2abs);
 &Getopt::Long::config('auto_abbrev');
 
 # ----------------------------------------
+
+#Explicitly get the directory of this script, in case the working directory
+#is something nasty like '/' (e.g. this happens when running under Icinga2).
+my $scriptdir = dirname(rel2abs($0));
+my $statfiledir = $scriptdir;
 
 my $TIMEOUT = 120;
 my %ERRORS = ('OK' , '0',
@@ -202,6 +213,7 @@ my $status = GetOptions(
 			"usesmtptls",\$usesmtptls,
 			"subjectident=s",\$subjectident,
 			"statfilename=s",\$statfilename,
+			"statfiledir=s",\$statfiledir,
                         "version",\$showversion
 			);
 
@@ -227,6 +239,24 @@ if ($statfilename){
 	my $statfilehash = Digest::MD5->new;
 	$statfilehash->add($sender.$receiver.$pophost.$popuser.$poppasswd.$smtphost);
 	$statfile = $statfile."_".$statfilehash->hexdigest.".stat";
+}
+
+if ($statfiledir) {
+
+  #If the directory doesn't exist (or isn't a directory)
+  if (! -d $statfiledir) {
+    nsexit("Given 'statfiledir' is not a directory",'CRITICAL');
+  }
+
+  #Get the system's directory separator (e.g. '/' on Linux or '\' on Windows')
+  my $dirsepchar = File::Spec->catfile('', '');
+  #If last character is not $dirsepchar (via negated regexp), append it
+  if ($statfiledir !~ /{$dirsepchar}$/) {
+    $statfiledir = $statfiledir . $dirsepchar;
+  }
+
+  #All together now!
+  $statfile = $statfiledir . $statfile;
 }
 
 # Try to read the ids of the last send emails out of statfile
@@ -461,6 +491,7 @@ sub usage {
   print "   -usesendmail=text  Use a sendmail binary (/usr/sbin/sendmail) instead of a SMTP server\n";
   print "   -statfile=text     File to save ids of messages ($statfile)\n";
   print "   -statfilename=text Similar like -statfile but add no hash to the filename\n";
+  print "   -statfiledir=text  Absolute path of directory for the statfile (default is script directory NOT working directory)\n";
   print "   -subjectident=text Identify the email. So we can distinct origin. (Default: 'E-Mail Ping')\n";
   print "   -lostwarn=num      WARNING-state if more than num lost emails\n";
   print "   -lostcrit=num      CRITICAL \n";


### PR DESCRIPTION
Changes detailed in commit comments (copy-pasted below, for quick reference). Tested thoroughly and in production use since July 16th, 2018, without issue.

Main changes are:
- Swapping the unmaintained Net::SMTP::TLS for Net::SMTP
- Adding RFC 2822 compliant email headers, to make spam filters less upset by these emails

```
# 2018-07-11 v1.4.4     BowTyTroll, TheTroll@BowTyTroll.com
# - Fix SMTP auth when "-usesmtptls"/Deprecated Net::SMTP::TLS for Net::SMTP
# - Add "-smtpehlo" option, with default value hostfqdn(), for SMTP HELO/EHLO
# - Add RFC 2822 compliant From, Date and Message-ID headers to emails
# - Add default imap port variables
# - Correct IMAP SSL/TLS port default from 585 to 993
# - Correct missing require for IO::Socket::SSL if using explicit IMAP SSL
# - Make "INBOX" the default $imapfolder
#
# 2018-07-11 v1.4.5     BowTyTroll, TheTroll@BowTyTroll.com
# - Add missing require directive for Mail::IMAPClient, when '-useimap' given
#
# 2018-07-14 v1.4.6     BowTyTroll, TheTroll@BowTyTroll.com
# - Add statfile directory parameter ('statfiledir')
# - Make default statfile directory the script directory (NOT working directory)
```