### PR TITLE
Fix Issue #5 - Compatibility with rfc5322 

### DIFF
--- a/check_email_loop
+++ b/check_email_loop
@@ -344,6 +344,7 @@ my $maildata = "From: <$sender>\n".
   "Date: " .  email_date() . "\n".
   "Message-Id: <" . md5_hex($serial) . "\@$smtpehlo>\n".
   "Subject: $subjectident [$serial]\n".
+  "\n".
   "This is an automatically sent E-Mail.\n".
   "It is not intended for a human reader.\n\n".
   "Serial No: $serial\n";


### PR DESCRIPTION
plesk-sendmail[3207]: S3207: Unable to prepare arguments for mail handlers.